### PR TITLE
experiemting with header width bug

### DIFF
--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -6,7 +6,7 @@ import UpcomingTitle from "@/components/events/UpcomingTitle";
 
 const OurEvents = () => {
   return (
-    <div className="flex flex-col items-center justify-center gap-4 p-8">
+    <div className="flex flex-col items-center justify-center gap-4">
       <Header
         title={"Events"}
         subtitle={"Explore when our next event is and make sure to stop by."}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,7 +9,7 @@ interface HeaderProps {
 
 const Header: React.FC<HeaderProps> = ({ title, subtitle, background }) => {
   return (
-    <div className="relative w-screen">
+    <div className="relative w-full">
       <Image
         src={background}
         className="absolute -z-20 h-[60vh] w-full md:flex"

--- a/src/components/events/Events.tsx
+++ b/src/components/events/Events.tsx
@@ -9,7 +9,7 @@ interface EventProps {
 
 const Events: React.FC<EventProps> = ({ date, time, title, desc }) => {
   return (
-    <div className="grid grid-cols-7 items-center overflow-hidden rounded-lg font-leap sm:h-1/3 sm:w-full">
+    <div className="mx-auto grid w-full max-w-6xl grid-cols-7 items-center overflow-hidden rounded-lg font-leap sm:h-1/3">
       <div className="col-span-1 flex h-full items-center justify-center bg-leap-mid-green">
         <div className="flex flex-col items-center justify-center px-10 py-7 text-center text-white">
           <div className="text-xl font-semibold md:text-3xl lg:text-4xl">

--- a/src/components/events/Events.tsx
+++ b/src/components/events/Events.tsx
@@ -9,7 +9,7 @@ interface EventProps {
 
 const Events: React.FC<EventProps> = ({ date, time, title, desc }) => {
   return (
-    <div className="mx-auto grid w-full max-w-6xl grid-cols-7 items-center overflow-hidden rounded-lg font-leap sm:h-1/3">
+    <div className="grid grid-cols-7 items-center overflow-hidden rounded-lg font-leap sm:h-1/3 sm:w-full">
       <div className="col-span-1 flex h-full items-center justify-center bg-leap-mid-green">
         <div className="flex flex-col items-center justify-center px-10 py-7 text-center text-white">
           <div className="text-xl font-semibold md:text-3xl lg:text-4xl">


### PR DESCRIPTION
I've been trying to adjust the "Events" header width since last night, making small tweaks here and there. This is the best I could get it so far.
I attempted to fix the layout issue by adding max-w-3xl to the parent div to limit its width and mx-auto to center it. However, I'm not sure how to refine it further. This change also causes the components below to shrink, which I think might be necessary to properly fix the overall width issue.
Could you double-check this for me
![image](https://github.com/user-attachments/assets/05d83a83-e643-401a-9a3a-ea8b04dc136b)
