### PR TITLE
cleaned up board cards

### DIFF
--- a/src/components/board/BoardMemberCards.tsx
+++ b/src/components/board/BoardMemberCards.tsx
@@ -33,13 +33,13 @@ const BoardMemberCards: React.FC<MemberProps> = ({
         >
           <div className="flex h-96 w-80 justify-center rounded-3xl border-8 border-white bg-leap-dark-green">
             <div className="flex flex-col items-center">
-              <div className="mt-5 flex h-60 w-60 justify-center rounded-3xl border-8 border-leap-light-green">
+              <div className="mt-5 flex h-60 w-60 justify-center rounded-xl border-8 border-leap-light-green">
                 <Image
                   src={img}
                   alt={name}
                   width={240}
                   height={240}
-                  className="rounded-2xl object-cover"
+                  className="rounded-sm object-cover"
                 />
               </div>
               <p className="mt-5 flex justify-center font-leap text-2xl font-bold text-white">

--- a/src/components/board/BoardMemberCards.tsx
+++ b/src/components/board/BoardMemberCards.tsx
@@ -22,8 +22,8 @@ const BoardMemberCards: React.FC<MemberProps> = ({
 }) => {
   const [flipped, setFlipped] = useState(false);
   return (
-    <div className="mb-20 mt-10 flex flex-col items-center justify-center">
-      <div className="mb-20 flex flex-row gap-20">
+    <div className="mb-10 mt-5 flex flex-col items-center justify-center md:mb-20 md:mt-10 lg:mb-20 lg:mt-10">
+      <div className="flex flex-row gap-20">
         <motion.div
           style={{ transformStyle: "preserve-3d" }}
           transition={{ duration: 0.7 }}
@@ -37,15 +37,15 @@ const BoardMemberCards: React.FC<MemberProps> = ({
                 <Image
                   src={img}
                   alt={name}
-                  width={230}
-                  height={220}
-                  className="rounded-2xl"
+                  width={240}
+                  height={240}
+                  className="rounded-2xl object-cover"
                 />
               </div>
               <p className="mt-5 flex justify-center font-leap text-2xl font-bold text-white">
                 {name}
               </p>
-              <p className="mt-1 flex justify-center font-leap text-2xl font-bold text-white">
+              <p className="mt-1 flex justify-center font-leap text-xl font-medium text-white">
                 {role}
               </p>
             </div>

--- a/src/components/board/BoardWrapper.tsx
+++ b/src/components/board/BoardWrapper.tsx
@@ -13,7 +13,7 @@ const BoardWrapper = () => {
         className="absolute -z-10 h-full w-full"
       />
 
-      <div className="mx-auto grid w-5/6 place-content-center justify-center sm:grid-cols-2 lg:grid-cols-3">
+      <div className="mx-auto grid w-5/6 place-content-center justify-center gap-x-32 sm:grid-cols-2 lg:grid-cols-3">
         {boardmembers.map(
           ({ name, role, img, whyLeap, majorInfo, careerGoal }) => (
             <BoardMemberCards


### PR DESCRIPTION
I fixed the images so that they're no longer squished/stretched! It should look normal now. The text for board members is smaller and less bold. Mobile responsiveness was adjusted so that cards no longer overlap, and vertical gaps are now smaller.

The only change I didn't implement was adjusting the roundness of the inner pictures. I wasn't sure what to do. Do I match the roundness of the inner picture/border to the roundness of the outer white border?

<img width="1012" alt="Screenshot 2025-03-05 at 10 58 48 PM" src="https://github.com/user-attachments/assets/f8e1dd9c-7c11-4b62-a4a8-3a053011222c" />
<img width="532" alt="Screenshot 2025-03-05 at 11 04 03 PM" src="https://github.com/user-attachments/assets/9f7fe574-dee9-4e81-a622-adc74f445855" />
